### PR TITLE
Update RasPyCam to v113

### DIFF
--- a/etc/raspycam/_internal/core/model.py
+++ b/etc/raspycam/_internal/core/model.py
@@ -58,7 +58,7 @@ class CameraCoreModel:
             "motion_logfile": "/tmp/motionLog.txt",  # Log file recording motion events during Monitor mode.
         }
 
-        # Set up internal flags.
+        # Set up internal flags
         self.current_status = (
             None  # Holds the current status string of the camera system
         )


### PR DESCRIPTION
# Release Summary

This PR updates the RasPyCam executable to the latest version `v113`, generated from the [RasPyCam](https://github.com/kaihokori/raspycam) repository.

## Changes Introduced

1. **Change X:**
   - [Text]

## Additional Notes

- **Manual Usage**: If you want to test the application manually, please follow the instructions provided in the [RasPyCam](https://github.com/kaihokori/raspycam) README.

## Changelog

The following is extracted from the official release notes of RasPyCam version `v113` accessible [here](https://github.com/kaihokori/RasPyCam/releases/tag/v113):


* Update deployment-full.yml by @kaihokori in https://github.com/kaihokori/RasPyCam/pull/134


**Full Changelog**: https://github.com/kaihokori/RasPyCam/compare/v112...v113

