### PR TITLE
Update RasPyCam to v118

### DIFF
--- a/etc/raspycam/_internal/core/process.py
+++ b/etc/raspycam/_internal/core/process.py
@@ -288,7 +288,7 @@ def start_background_process(config_filepath):
 
         time.sleep(0.01)  # Small delay before next iteration
 
-    print("Shutting down gracefully...")
+    print("\033[92mShutting down gracefully\033[0m")
     cam.current_status = "halted"
     cmd_processing_thread.join()  # Wait for command processing thread to finish
     for t in threads:


### PR DESCRIPTION
# Release Summary

This PR updates the RasPyCam executable to the latest version `v118`, generated from the [RasPyCam](https://github.com/kaihokori/raspycam) repository.

## Changes Introduced

1. **Change X:**
   - [Text]

## Additional Notes

- **Manual Usage**: If you want to test the application manually, please follow the instructions provided in the [RasPyCam](https://github.com/kaihokori/raspycam) README.

## Changelog

The following is extracted from the official release notes of RasPyCam version `v118` accessible [here](https://github.com/kaihokori/RasPyCam/releases/tag/v118):


* Update deployment-full.yml by @kaihokori in https://github.com/kaihokori/RasPyCam/pull/139


**Full Changelog**: https://github.com/kaihokori/RasPyCam/compare/v117...v118

